### PR TITLE
Making it so that options must be an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ di({
 
 ### `options`
 
-If the module declared in `require` returns a function and the `options` property is an array or object the function will be called with the processed options. The function can return a promise in which case it will wait until the promise is resolved. With a `mainmodule.js` like this:
+If the module declared in `require` returns a function the `options` property will be passed as the `arguments` to that function. The function can return a promise in which case it will wait until the promise is resolved. With a `mainmodule.js` like this:
 
 ```js
 module.exports = function(options) {
@@ -56,9 +56,9 @@ And a `main.json` like this:
 ```js
 {
   "require": "./mainmodule",
-  "options": {
+  "options": [{
     "text": { "require": "./world" }
-  }
+  }]
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -97,8 +97,12 @@ function process(data, convert = value => value) {
       // If the module is a function and `options` or `arguments`
       // is specified in the configuration, run that function with options or arguments
       if(result.options && typeof mod === 'function') {
-        const args = Array.isArray(result.options) ?
-          result.options : [ result.options ];
+        if (!Array.isArray(result.options)) {
+            throw new Error(`Options for ${data.require} have to be an array`);
+        }
+
+        const args = result.options;
+
         debug(`Calling function returned from ${data.require} with`, args);
 
         // Call the module with the given arguments since it can return a

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,7 @@ describe('json-di', () => {
       require: './loader/first.json'
     }, __filename);
 
-    assert.equal(result.module.options.test.module.module, 'world');
+    assert.equal(result.module.options[0].test.module.module, 'world');
   });
 
   it('`load` can require Node builtins', function() {
@@ -25,7 +25,7 @@ describe('json-di', () => {
     assert.equal(result.module, require('path'));
   });
 
-  it('`process` simple processing', function(done) {
+  it('`process` returns an error when options is not an array', function(done) {
     process({
       require: 'somewhere.json',
       module: {
@@ -33,6 +33,24 @@ describe('json-di', () => {
           return `${opts.test} ran`;
         },
         options: { test: 'testing' }
+      }
+    }).then(() => {
+      assert.equal(true, false, 'Should not get here');
+      done();
+    }).catch(error => {
+      assert.notEqual(error, undefined);
+      done();
+    });
+  });
+
+  it('`process` simple processing', function(done) {
+    process({
+      require: 'somewhere.json',
+      module: {
+        module: function(opts) {
+          return `${opts.test} ran`;
+        },
+        options: [{ test: 'testing' }]
       }
     }).then(data => {
       assert.equal(data, 'testing ran');
@@ -47,7 +65,7 @@ describe('json-di', () => {
         module: function(opts) {
           return { result: `${opts.test} ran` };
         },
-        options: { test: 'testing' },
+        options: [{ test: 'testing' }],
         hi: 'there',
         otherOption: { test: true }
       }
@@ -79,7 +97,7 @@ describe('json-di', () => {
             setTimeout(() => resolve(`${options.test} ran`), 100)
           );
         },
-        options: { test: 'testing' }
+        options: [{ test: 'testing' }]
       }
     }).then(data => {
       assert.equal(data, 'testing ran');

--- a/test/loader/first.json
+++ b/test/loader/first.json
@@ -1,11 +1,11 @@
 {
   "require": "./sub/with-options",
-  "options": {
+  "options": [{
     "test": {
       "require": "./sub/second.json"
     },
     "other": "thing",
     "path": { "require": "path" }
-  },
+  }],
   "extended": { "require": "./sub/hello" }
 }


### PR DESCRIPTION
This removes any ambiguity around when `options` should be an array and when it should be an object. It should always be an array.
