### PR TITLE
Include the original node error message when a module cannot load.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ function load(mod, parent) {
     try {
       loadedModule = require(location);
     } catch(error) {
-      throw new Error(`Can not load module ${name} defined in ${parent} (\`${JSON.stringify(data)}\`)`);
+      throw new Error(`Cannot load module ${name} defined in ${parent} (\`${JSON.stringify(data)}\`), ${error.message}`);
     }
 
     if(path.extname(name) === '.json') {


### PR DESCRIPTION
json-di was throwing the error:

```
Cannot load module ./messages.model.js defined in /Users/marshall/Sites/feathers-bs/src/services/messages/messages.json (`{"require":"./messages.model.js"}`)
```

I had installed `feathers-nedb`, but forgot `nedb`, so the actual node error was

```
Cannot find module 'nedb'
```

 So now the output appends the original node error.message to the error message to make debugging easier.
